### PR TITLE
Fix typo in index.ts

### DIFF
--- a/packages/graphqlgen/src/index.ts
+++ b/packages/graphqlgen/src/index.ts
@@ -128,7 +128,7 @@ function writeTypes(types: string, config: GraphQLGenDefinition): void {
   }
   console.log(
     chalk.green(
-      `Resolver interface definitons & default resolvers generated at ${
+      `Resolver interface definitions & default resolvers generated at ${
         config.output
       }`,
     ),


### PR DESCRIPTION
Hi!

I just noticed that the message regarding resolver interface definitions was misspelled a bit, so I fixed it.